### PR TITLE
chore: replace deprecated `COMPOSER_TOKEN` with `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -36,7 +36,7 @@ jobs:
           extensions: intl, json, mbstring, xml
           coverage: none
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         run: echo "COMPOSER_CACHE_FILES_DIR=$(composer config cache-files-dir)" >> $GITHUB_ENV

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -31,7 +31,7 @@ jobs:
           extensions: json, tokenizer
           coverage: none
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         run: echo "COMPOSER_CACHE_FILES_DIR=$(composer config cache-files-dir)" >> $GITHUB_ENV

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -40,7 +40,7 @@ jobs:
           extensions: intl, json, mbstring, xml
           coverage: none
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         run: echo "COMPOSER_CACHE_FILES_DIR=$(composer config cache-files-dir)" >> $GITHUB_ENV

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -39,7 +39,7 @@ jobs:
           extensions: intl, json, mbstring, gd, xdebug, xml, sqlite3
           coverage: xdebug
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         run: echo "COMPOSER_CACHE_FILES_DIR=$(composer config cache-files-dir)" >> $GITHUB_ENV

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -36,7 +36,7 @@ jobs:
           extensions: intl, json, mbstring, xml
           coverage: none
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         run: echo "COMPOSER_CACHE_FILES_DIR=$(composer config cache-files-dir)" >> $GITHUB_ENV

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -40,7 +40,7 @@ jobs:
           extensions: intl, json, mbstring, xml
           coverage: none
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         run: echo "COMPOSER_CACHE_FILES_DIR=$(composer config cache-files-dir)" >> $GITHUB_ENV


### PR DESCRIPTION
Except for major versions of composer, For other tools when you specify only the major version or the version in major.minor format for any tool you can get rate limited by GitHub's API. To avoid this, it is recommended to provide a [GitHub OAuth token](https://github.com/shivammathur/setup-php#composer-github-oauth). You can do that by setting GITHUB_TOKEN environment variable. The COMPOSER_TOKEN environment variable has been deprecated in favor of GITHUB_TOKEN and will be removed in the next major version.
https://github.com/shivammathur/setup-php#wrench-tools-support