### PR TITLE
fix: Update Toolbar for changes in CI 4.4

### DIFF
--- a/src/Debug/Toolbar.php
+++ b/src/Debug/Toolbar.php
@@ -11,6 +11,7 @@ use Config\Services;
 use Kint\Kint;
 use Michalsn\CodeIgniterHtmx\HTTP\IncomingRequest;
 use Michalsn\CodeIgniterHtmx\HTTP\Response;
+use Config\Toolbar as ToolbarConfig;
 
 class Toolbar extends BaseToolbar
 {
@@ -36,7 +37,7 @@ class Toolbar extends BaseToolbar
                 return;
             }
 
-            $toolbar = Services::toolbar(config(self::class));
+            $toolbar = Services::toolbar(config(ToolbarConfig::class));
             $stats   = $app->getPerformanceStats();
             $data    = $toolbar->run(
                 $stats['startTime'],


### PR DESCRIPTION
Updates the Toolbar config used within Debug\Toolbar to match what CI is doing now in 4.4. 