### PR TITLE
fix: Crash when caching config

### DIFF
--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -7,6 +7,7 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\UserAgent;
 use Config\App;
+use Config\Optimize;
 use Config\Paths;
 use Config\Services as AppServices;
 use Config\Toolbar as ToolbarConfig;
@@ -32,11 +33,9 @@ class Services extends BaseService
             return static::getSharedInstance('renderer', $viewPath, $config);
         }
 
-        if ($viewPath === null && ENVIRONMENT === 'testing') {
-            $viewPath = SUPPORTPATH . 'Views';
-        } else {
-            $viewPath = $viewPath ?: (new Paths())->viewDirectory;
-        }
+        $viewPath = $viewPath ?: ((new Optimize())->configCacheEnabled ?
+            (new Paths())->viewDirectory :
+            config('Paths')->viewDirectory);
 
         $config ??= config('View');
 

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -32,7 +32,12 @@ class Services extends BaseService
             return static::getSharedInstance('renderer', $viewPath, $config);
         }
 
-        $viewPath = $viewPath ?: (new Paths())->viewDirectory;
+        if ($viewPath === null && ENVIRONMENT === 'testing') {
+            $viewPath = SUPPORTPATH . 'Views';
+        } else {
+            $viewPath = $viewPath ?: (new Paths())->viewDirectory;
+        }
+
         $config ??= config('View');
 
         return new View($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -7,6 +7,7 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\UserAgent;
 use Config\App;
+use Config\Paths;
 use Config\Services as AppServices;
 use Config\Toolbar as ToolbarConfig;
 use Config\View as ViewConfig;
@@ -31,7 +32,7 @@ class Services extends BaseService
             return static::getSharedInstance('renderer', $viewPath, $config);
         }
 
-        $viewPath = $viewPath ?: config('Paths')->viewDirectory;
+        $viewPath = $viewPath ?: (new Paths())->viewDirectory;
         $config ??= config('View');
 
         return new View($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());

--- a/tests/CommonTest.php
+++ b/tests/CommonTest.php
@@ -12,6 +12,8 @@ final class CommonTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        config('Paths')->viewDirectory = SUPPORTPATH . 'Views';
     }
 
     public function testViewFragmentNone(): void

--- a/tests/CommonTest.php
+++ b/tests/CommonTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\Paths;
 
 /**
  * @internal
@@ -13,8 +12,6 @@ final class CommonTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        (new Paths())->viewDirectory = SUPPORTPATH . 'Views';
     }
 
     public function testViewFragmentNone(): void

--- a/tests/CommonTest.php
+++ b/tests/CommonTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Paths;
 
 /**
  * @internal
@@ -13,7 +14,7 @@ final class CommonTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        config('Paths')->viewDirectory = SUPPORTPATH . 'Views';
+        (new Paths())->viewDirectory = SUPPORTPATH . 'Views';
     }
 
     public function testViewFragmentNone(): void


### PR DESCRIPTION
See https://github.com/codeigniter4/CodeIgniter4/issues/9181

It is not recommended to use `config('Paths')` Configuration caching will stop working.
This applies to all configurations that do not extend `BaseConfig`.