### PR TITLE
refactor: manage config cache just like in the original codeigniter source code

### DIFF
--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -7,7 +7,6 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\UserAgent;
 use Config\App;
-use Config\Optimize;
 use Config\Paths;
 use Config\Services as AppServices;
 use Config\Toolbar as ToolbarConfig;
@@ -33,9 +32,7 @@ class Services extends BaseService
             return static::getSharedInstance('renderer', $viewPath, $config);
         }
 
-        $viewPath = $viewPath ?: ((new Optimize())->configCacheEnabled ?
-            (new Paths())->viewDirectory :
-            config('Paths')->viewDirectory);
+        $viewPath = $viewPath ?: (new Paths())->viewDirectory;
 
         $config ??= config('View');
 

--- a/tests/CommonTest.php
+++ b/tests/CommonTest.php
@@ -13,7 +13,7 @@ final class CommonTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        config('Paths')->viewDirectory = SUPPORTPATH . 'Views';
+        service('renderer', SUPPORTPATH . 'Views');
     }
 
     public function testViewFragmentNone(): void


### PR DESCRIPTION
The problem of the path to the tests can be solved much more simply. Unfortunately, I hadn't thought of that before.