### PR TITLE
Move tests cache to ./build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,5 @@ nb-configuration.xml
 
 /results/
 /phpunit*.xml
-/.phpunit.*.cache
 
 /.php-cs-fixer.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
     stopOnFailure="false"
     stopOnIncomplete="false"
     stopOnSkipped="false"
-    cacheDirectory=".phpunit.cache"
+    cacheDirectory="build/.phpunit.cache"
     beStrictAboutCoverageMetadata="true">
     <coverage includeUncoveredFiles="true">
         <report>


### PR DESCRIPTION
`.gitignore` has an incorrect condition `/.phpunit.*.cache`.
But folder **/.phpunit.cache** is being created, which can go to Git.
Moved it as in the original CI4 repository