### PR TITLE
feat: Improve `hxLocation()` redirect

### DIFF
--- a/docs/redirect_response.md
+++ b/docs/redirect_response.md
@@ -13,6 +13,7 @@ Sets the `HX-Location` header to redirect without reloading the whole page.
 ```php
 return redirect()->hxLocation('/path');
 ```
+For convenience, the set path with `http(s)://` will be converted to relative. Like this: `http://example.com/articles/` it will become `/articles/`.
 
 For more information, please see [hx-location](https://htmx.org/headers/hx-location/).
 

--- a/src/HTTP/RedirectResponse.php
+++ b/src/HTTP/RedirectResponse.php
@@ -21,6 +21,11 @@ class RedirectResponse extends BaseRedirectResponse
         ?array $values = null,
         ?array $headers = null
     ): RedirectResponse {
+        // single_service
+        if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
+            $path = (string) service('uri', $path, false)->withScheme('')->setHost('');
+        }
+
         $data = ['path' => '/' . ltrim($path, '/')];
 
         if ($source !== null) {

--- a/tests/HTTP/RedirectResponseTest.php
+++ b/tests/HTTP/RedirectResponseTest.php
@@ -31,6 +31,21 @@ final class RedirectResponseTest extends CIUnitTestCase
         $this->assertSame(200, $this->response->getStatusCode());
     }
 
+    public function testHxLocationWithFullPath(): void
+    {
+        $this->response = $this->response->hxLocation('https://example.com/foo1');
+
+        $this->assertSame(json_encode(['path' => '/foo1']), $this->response->getHeaderLine('HX-Location'));
+
+        $this->response = $this->response->hxLocation('http://example.com/foo2');
+
+        $this->assertSame(json_encode(['path' => '/foo2']), $this->response->getHeaderLine('HX-Location'));
+
+        $this->response = $this->response->hxLocation('http://example.com/foo3?page=1&sort=ASC#top');
+
+        $this->assertSame(json_encode(['path' => '/foo3?page=1&sort=ASC#top']), $this->response->getHeaderLine('HX-Location'));
+    }
+
     public function testHxLocationWithSourceAndEvent(): void
     {
         $this->response = $this->response->hxLocation(path: '/foo', source: '#myElem', event: 'doubleclick');


### PR DESCRIPTION
Converting the full URL path to a relative. No protocol is required for `HX-Location` header.

See https://github.com/michalsn/codeigniter-htmx/issues/79#issuecomment-2410660298
