### PR TITLE
fix: add void return type to Toolbar::prepare() for CI4.7 compatibility

### DIFF
--- a/src/Debug/Toolbar.php
+++ b/src/Debug/Toolbar.php
@@ -20,7 +20,7 @@ class Toolbar extends BaseToolbar
      *
      * @psalm-suppress UndefinedClass
      */
-    public function prepare(?RequestInterface $request = null, ?ResponseInterface $response = null)
+    public function prepare(?RequestInterface $request = null, ?ResponseInterface $response = null): void
     {
         /**
          * @var IncomingRequest|null $request


### PR DESCRIPTION
## Summary
Adds the `void` return type to `Toolbar::prepare()` method to maintain compatibility with CodeIgniter 4.7.0.

## Changes
- Added `: void` return type to `Toolbar::prepare()` method in `src/Debug/Toolbar.php`

## Reason
CodeIgniter 4.7.0 updated the base `Toolbar` class to require a `void` return type on the `prepare()` method. Without this change, the following fatal error occurs:

```
Declaration of Michalsn\CodeIgniterHtmx\Debug\Toolbar::prepare(?CodeIgniter\HTTP\RequestInterface $request = null, ?CodeIgniter\HTTP\ResponseInterface $response = null) must be compatible with CodeIgniter\Debug\Toolbar::prepare(?CodeIgniter\HTTP\RequestInterface $request = null, ?CodeIgniter\HTTP\ResponseInterface $response = null): void
```

## Testing
- Verified that the method signature now matches the parent class
- No functional changes to the method implementation