### PR TITLE
fix: add missing push parameters to hxLocation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - develop
+      - v2
     paths:
-      - 'docs/*'
+      - 'docs/**'
       - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -16,8 +20,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy --force
+      - run: pip install -r requirements-docs.txt
+      - run: git fetch origin gh-pages --depth=1
+      - run: git config user.name github-actions[bot]
+      - run: git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Deploy docs with mike
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          case "$BRANCH_NAME" in
+            develop)
+              mike deploy --push --update-aliases dev
+              ;;
+            v2)
+              mike deploy --push --update-aliases v2 latest
+              mike set-default --push latest
+              ;;
+            *)
+              echo "Unsupported docs branch: $BRANCH_NAME"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,11 +35,11 @@ jobs:
         run: |
           case "$BRANCH_NAME" in
             develop)
-              mike deploy --push --update-aliases dev
+              mike deploy --push --update-aliases dev latest
+              mike set-default --push latest
               ;;
             v2)
-              mike deploy --push --update-aliases v2 latest
-              mike set-default --push latest
+              mike deploy --push --update-aliases v2
               ;;
             *)
               echo "Unsupported docs branch: $BRANCH_NAME"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: CodeIgniter HTMX
 site_description: Documentation for HTMX helper library for CodeIgniter 4 framework
+site_url: https://michalsn.github.io/codeigniter-htmx/
 
 theme:
   name: material
@@ -25,6 +26,8 @@ theme:
 
 extra:
   homepage: https://michalsn.github.io/codeigniter-htmx
+  version:
+    provider: mike
 
   social:
     - icon: fontawesome/brands/github
@@ -38,6 +41,10 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.highlight:
       use_pygments: false
+
+plugins:
+  - search
+  - mike
 
 extra_css:
   - assets/github-dark-dimmed.css

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs-material
+mike


### PR DESCRIPTION
**Description**
I came across an issue with your amazing library and created a small fix.
As per [hx-location documentation](https://htmx.org/headers/hx-location/) htmx consumes the `push` parameter but your API doesnt expose it.

Just a small addition. Tell me if this would need a test.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
