### PR TITLE
fix: add missing parameters to hxLocation() method

### DIFF
--- a/src/HTTP/RedirectResponse.php
+++ b/src/HTTP/RedirectResponse.php
@@ -17,6 +17,7 @@ class RedirectResponse extends BaseRedirectResponse
         ?string $source = null,
         ?string $event = null,
         ?string $target = null,
+        ?string $push = null,
         ?string $swap = null,
         ?array $values = null,
         ?array $headers = null,
@@ -37,6 +38,10 @@ class RedirectResponse extends BaseRedirectResponse
 
         if ($target !== null) {
             $data['target'] = $target;
+        }
+
+        if ($push !== null) {
+            $data['push'] = $push;
         }
 
         if ($swap !== null) {

--- a/src/HTTP/RedirectResponse.php
+++ b/src/HTTP/RedirectResponse.php
@@ -11,16 +11,31 @@ class RedirectResponse extends BaseRedirectResponse
     /**
      * Sets the HX-Location to redirect
      * without reloading the whole page.
+     *
+     * @var string  - Path is required and is url to load the response from
+     * @var ?string - the source element of the request
+     * @var ?string - an event that “triggered” the request
+     * @var ?string - a callback that will handle the response HTML
+     * @var ?string - the target to swap the response into
+     * @var ?string - how the response will be swapped in relative to the target
+     * @var ?string - values to submit with the request
+     * @var ?string - headers to submit with the request
+     * @var ?string - allows you to select the content you want swapped from a response
+     * @var ?string - set to 'false' or a path string to prevent or override the URL pushed to browser location history
+     * @var ?string - a path string to replace the URL in the browser location history
      */
     public function hxLocation(
         string $path,
         ?string $source = null,
         ?string $event = null,
         ?string $target = null,
-        ?string $push = null,
         ?string $swap = null,
         ?array $values = null,
         ?array $headers = null,
+        ?string $push = null,
+        ?string $replace = null,
+        ?string $select = null,
+        ?string $handler = null,
     ): RedirectResponse {
         if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
             $path = (string) service('uri', $path, false)->withScheme('')->setHost('');
@@ -40,10 +55,6 @@ class RedirectResponse extends BaseRedirectResponse
             $data['target'] = $target;
         }
 
-        if ($push !== null) {
-            $data['push'] = $push;
-        }
-
         if ($swap !== null) {
             $this->validateSwap($swap);
             $data['swap'] = $swap;
@@ -55,6 +66,22 @@ class RedirectResponse extends BaseRedirectResponse
 
         if ($headers !== null && $headers !== []) {
             $data['headers'] = $headers;
+        }
+
+        if ($push !== null) {
+            $data['push'] = $push;
+        }
+
+        if ($replace !== null) {
+            $data['replace'] = $replace;
+        }
+
+        if ($select !== null) {
+            $data['select'] = $select;
+        }
+
+        if ($handler !== null) {
+            $data['handler'] = $handler;
         }
 
         return $this->setStatusCode(200)->setHeader('HX-Location', json_encode($data));

--- a/tests/HTTP/RedirectResponseTest.php
+++ b/tests/HTTP/RedirectResponseTest.php
@@ -68,6 +68,16 @@ final class RedirectResponseTest extends CIUnitTestCase
         $this->assertSame(200, $this->response->getStatusCode());
     }
 
+    public function testHxLocationWithPushReplaceSelectAndHandler(): void
+    {
+        $this->response = $this->response->hxLocation(path: '/foo', push: 'true', replace: 'false', select: '#myDiv', handler: 'myHandler');
+
+        $this->assertTrue($this->response->hasHeader('HX-Location'));
+        $expected = json_encode(['path' => '/foo', 'push' => 'true', 'replace' => 'false', 'select' => '#myDiv', 'handler' => 'myHandler']);
+        $this->assertSame($expected, $this->response->getHeaderLine('HX-Location'));
+        $this->assertSame(200, $this->response->getStatusCode());
+    }
+
     public function testHxLocationWithValuesAndHeaders(): void
     {
         $this->response = $this->response->hxLocation(path: '/foo', values: ['myVal' => 'My Value'], headers: ['myHeader' => 'My Value']);


### PR DESCRIPTION
**Description**
I came across an issue with your amazing library and created a small fix.
As per [hx-location documentation](https://htmx.org/headers/hx-location/) htmx consumes the `push` parameter but your API doesnt expose it.

Added all missing HX-Location-params along the way too.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
